### PR TITLE
fix issue with :install-python action in install_from_release

### DIFF
--- a/cookbooks/graphite/attributes/default.rb
+++ b/cookbooks/graphite/attributes/default.rb
@@ -4,7 +4,7 @@ default[:graphite][:data_dir]              = '/var/lib/graphite/storage'
 default[:graphite][:log_dir]               = '/var/log/graphite'
 default[:graphite][:pid_dir]               = '/var/run/graphite'
 
-default[:graphite][:user]                  = 'graphite'
+default[:graphite][:user]                  = 'www-data'
 default[:graphite][:carbon   ][:user]      = 'www-data'
 default[:graphite][:whisper  ][:user]      = 'www-data'
 default[:graphite][:dashboard][:user]      = 'www-data'
@@ -20,9 +20,9 @@ default[:graphite][:carbon   ][:run_state] = :start
 default[:graphite][:whisper  ][:run_state] = :start
 default[:graphite][:dashboard][:run_state] = :start
 
-default[:graphite][:carbon   ][:line_rcvr_addr]       = "127.0.0.1"
-default[:graphite][:carbon   ][:pickle_rcvr_addr]     = "127.0.0.1"
-default[:graphite][:carbon   ][:cache_query_addr]     = "127.0.0.1"
+default[:graphite][:carbon   ][:line_rcvr_addr]       = "0.0.0.0"
+default[:graphite][:carbon   ][:pickle_rcvr_addr]     = "0.0.0.0"
+default[:graphite][:carbon   ][:cache_query_addr]     = "0.0.0.0"
 
 default[:graphite][:carbon   ][:version]              = "0.9.7"
 default[:graphite][:carbon   ][:release_url]          = "http://launchpadlibrarian.net/61904798/carbon-0.9.7.tar.gz"

--- a/cookbooks/graphite/metadata.rb
+++ b/cookbooks/graphite/metadata.rb
@@ -51,7 +51,7 @@ attribute "graphite/pid_dir",
 attribute "graphite/user",
   :display_name          => "",
   :description           => "",
-  :default               => "graphite"
+  :default               => "www-data"
 
 attribute "graphite/carbon/line_rcvr_addr",
   :display_name          => "",

--- a/cookbooks/graphite/recipes/carbon.rb
+++ b/cookbooks/graphite/recipes/carbon.rb
@@ -49,21 +49,31 @@ end
 
 template "#{node[:graphite][:conf_dir]}/storage-schemas.conf"
 
-template "/etc/init.d/carbon-cache" do
-  source "init.d_carbon-cache.erb"
-  mode 0755
-  variables :carbon_dir => node[:graphite][:carbon][:home_dir]
+link "#{node[:graphite][:carbon][:home_dir]}/conf/carbon.conf" do
+  to "#{node[:graphite][:conf_dir]}/carbon.conf"
+  action :create
 end
+
+link "#{node[:graphite][:carbon][:home_dir]}/conf/storage-schemas.conf" do
+  to "#{node[:graphite][:conf_dir]}/storage-schemas.conf"
+  action :create
+end
+
+#template "/etc/init.d/carbon-cache" do
+#  source "init.d_carbon-cache.erb"
+#  mode 0755
+#  variables :carbon_dir => node[:graphite][:carbon][:home_dir]
+#end
 
 # # execute "setup carbon sysvinit script" do
 # #   command "ln -nsf /opt/graphite/bin/carbon-cache.py /etc/init.d/carbon-cache"
 # #   creates "/etc/init.d/carbon-cache"
 # # end
 #
-# service "carbon-cache" do
-# #   running true
-# #   start_command "/opt/graphite/bin/carbon-cache.py start"
-# #   stop_command "/opt/graphite/bin/carbon-cache.py stop"
-#   action [ :enable, :start ]
-# #   action :start
-# end
+service "carbon-cache" do
+  running true
+  start_command "#{node[:graphite][:carbon][:home_dir]}/bin/carbon-cache.py start"
+  stop_command "#{node[:graphite][:carbon][:home_dir]}/bin/carbon-cache.py stop"
+  action [ :enable, :start ]
+  action :start
+end

--- a/cookbooks/graphite/recipes/whisper.rb
+++ b/cookbooks/graphite/recipes/whisper.rb
@@ -28,5 +28,5 @@ install_from_release('whisper') do
   home_dir      node[:graphite][:whisper][:home_dir]
   checksum      node[:graphite][:whisper][:release_url_checksum]
   action        [:install_python]
-  not_if{ File.exists?("/usr/local/lib/python2.6/dist-packages/whisper-#{node[:graphite][:whisper][:version]}.egg-info") }
+#  not_if{ File.exists?("/usr/local/lib/python2.6/dist-packages/whisper-#{node[:graphite][:whisper][:version]}.egg-info") }
 end

--- a/cookbooks/graphite/templates/default/storage-schemas.conf.erb
+++ b/cookbooks/graphite/templates/default/storage-schemas.conf.erb
@@ -16,11 +16,11 @@ priority = 10
 pattern = .*
 retentions = 60:43200,900:350400
 
-#[stats]
-#priority = 100
-#pattern = ^stats\..*
-#retentions = 10:2160,60:10080,600:262974
-#
+[stats]
+priority = 100
+pattern = ^stats\..*
+retentions = 10:2160,60:10080,600:262974
+
 #[catchall]
 #priority = 0
 #pattern = ^.*

--- a/cookbooks/install_from/providers/release.rb
+++ b/cookbooks/install_from/providers/release.rb
@@ -126,7 +126,7 @@ action :install_python do
   action_install
 
   bash "install #{new_resource.name} with python" do
-    command "python setup.py install"
+    code "python setup.py install"
     cwd           new_resource.install_dir
   end
 end

--- a/cookbooks/install_from/resources/release.rb
+++ b/cookbooks/install_from/resources/release.rb
@@ -100,6 +100,7 @@ def assume_defaults!
   @release_file     ||= ::File.join(prefix_root, 'src',   "#{name}-#{version}.#{release_ext}")
   @expand_cmd ||=
     case release_ext
+    when 'tar'     then untar_cmd('xf', release_file, install_dir)
     when 'tar.gz'  then untar_cmd('xzf', release_file, install_dir)
     when 'tar.bz2' then untar_cmd('xjf', release_file, install_dir)
     when 'zip'     then unzip_cmd(release_file, install_dir)


### PR DESCRIPTION
I noticed that I wasn't able to get a graphite installation going with ironfan without making this change.  It appears that the :install-python action is specifying the shell command via 'command' but it should be 'code'.
