### PR TITLE
Fix exception when `selects :single` is used

### DIFF
--- a/cookbooks/volumes/definitions/volume_dirs.rb
+++ b/cookbooks/volumes/definitions/volume_dirs.rb
@@ -71,7 +71,7 @@ define(:volume_dirs,
     volumes = volumes_tagged(node,
       "#{sys}_#{subsys}_#{aspect}", "#{sys}_#{aspect}", params[:type], 'fallback')
     # singularize if :single
-    volumes = [volumes.first] if (params[:selects] == :single)
+    volumes = Hash[*volumes.first] if (params[:selects] == :single)
     # slap path on the end of volume roots
     paths  = volumes.map{|vol, vol_info| ::File.expand_path(sub_path, vol_info[:mount_point]) }
   end


### PR DESCRIPTION
If params[:selects] == :single, prior to this change volumes was turned into
an array instead of a hash.  This caused vol_info to be nil on line 76,
resulting in an exception when '[]' was called on it.

I hit this when volume_dirs was called from `rabbitmq:server` and [another user here](http://community.opscode.com/chat/chef/2012-04-20) (search for "volume_dirs") appears to have hit this on `elasticsearch::server`, [like so](https://gist.github.com/98f52689acd474e10bde).
