### PR TITLE
Support default rvm group_id as well

### DIFF
--- a/cookbooks/rvm/recipes/system.rb
+++ b/cookbooks/rvm/recipes/system.rb
@@ -62,14 +62,13 @@ end
 
 # Build the rvm group ahead of time, if it is set. This allows avoiding
 # collision with later processes which may set a guid explicitly
-if node['rvm']['group_id'] != 'default'
-  g = group 'rvm' do
-    group_name 'rvm'
-    gid        node['rvm']['group_id']
-    action     :nothing
-  end
-  g.run_action(:create)
+rvm_group_id = (node['rvm']['group_id'] == 'default') ? nil : node['rvm']['group_id']
+g = group 'rvm' do
+  group_name 'rvm'
+  gid        rvm_group_id
+  action     :nothing
 end
+g.run_action(:create)
 
 i = execute "install system-wide RVM" do
   user      "root"


### PR DESCRIPTION
I think that the handling of group_id doesn't work as expected if you choose to use the default behavior.

Specifically, I think that choosing the default (node['rvm']['group_id'] == 'default') means that no rvm group is created before the rest of the rvm::system recipe run, which leads to an exception in this code:

t = template  "/etc/rvmrc" do
  source  "rvmrc.erb"
  owner   "root"
  group   "rvm"
  mode    "0644"
  ...

because the 'rvm' group doesn't exist when this code is run.

Here's what the exception looks like:

[Mon, 18 Jun 2012 18:14:59 +0000] INFO: Processing template[/etc/rvmrc] action create (rvm::system line 90)
[Mon, 18 Jun 2012 18:14:59 +0000] ERROR: template[/etc/rvmrc](rvm::system line 90) has had an error
[Mon, 18 Jun 2012 18:14:59 +0000] ERROR: template[/etc/rvmrc](/var/chef/cache/cookbooks/rvm/recipes/system.rb:90:in `from_file') had an error:
template[/etc/rvmrc](rvm::system line 90) had an error: Chef::Exceptions::GroupIDNotFound: cannot determine group id for 'rvm', does the group exist on this system?
/usr/lib/ruby/vendor_ruby/chef/file_access_control/unix.rb:79:in `target_gid'
/usr/lib/ruby/vendor_ruby/chef/file_access_control/unix.rb:83:in`set_group'
/usr/lib/ruby/vendor_ruby/chef/file_access_control/unix.rb:31:in `set_all'
/usr/lib/ruby/vendor_ruby/chef/provider/template.rb:89:in`set_all_access_controls'
/usr/lib/ruby/vendor_ruby/chef/provider/template.rb:43:in `action_create'
/usr/lib/ruby/vendor_ruby/chef/mixin/template.rb:48:in`render_template'
/usr/lib/ruby/1.8/tempfile.rb:188:in `open'
/usr/lib/ruby/vendor_ruby/chef/mixin/template.rb:45:in`render_template'
/usr/lib/ruby/vendor_ruby/chef/provider/template.rb:99:in `render_with_context'
/usr/lib/ruby/vendor_ruby/chef/provider/template.rb:39:in`action_create'
/usr/lib/ruby/vendor_ruby/chef/resource.rb:454:in `send'
/usr/lib/ruby/vendor_ruby/chef/resource.rb:454:in`run_action'
/usr/lib/ruby/vendor_ruby/chef/runner.rb:49:in `run_action'
/usr/lib/ruby/vendor_ruby/chef/runner.rb:85:in`converge'
/usr/lib/ruby/vendor_ruby/chef/runner.rb:85:in `each'
/usr/lib/ruby/vendor_ruby/chef/runner.rb:85:in`converge'
/usr/lib/ruby/vendor_ruby/chef/resource_collection.rb:94:in `execute_each_resource'
/usr/lib/ruby/vendor_ruby/chef/resource_collection/stepable_iterator.rb:116:in`call'
/usr/lib/ruby/vendor_ruby/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
/usr/lib/ruby/vendor_ruby/chef/resource_collection/stepable_iterator.rb:85:in`step'
/usr/lib/ruby/vendor_ruby/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
/usr/lib/ruby/vendor_ruby/chef/resource_collection/stepable_iterator.rb:55:in`each_with_index'
/usr/lib/ruby/vendor_ruby/chef/resource_collection.rb:92:in `execute_each_resource'
/usr/lib/ruby/vendor_ruby/chef/runner.rb:80:in`converge'
/usr/lib/ruby/vendor_ruby/chef/client.rb:330:in `converge'
/usr/lib/ruby/vendor_ruby/chef/client.rb:163:in`run'
/usr/lib/ruby/vendor_ruby/chef/application/client.rb:254:in `run_application'
/usr/lib/ruby/vendor_ruby/chef/application/client.rb:241:in`loop'
/usr/lib/ruby/vendor_ruby/chef/application/client.rb:241:in `run_application'
/usr/lib/ruby/vendor_ruby/chef/application.rb:70:in`run'
/usr/bin/chef-client:25
