### PR TITLE
Updated RVM Master URL

### DIFF
--- a/cookbooks/rvm/attributes/default.rb
+++ b/cookbooks/rvm/attributes/default.rb
@@ -24,7 +24,7 @@ default['rvm']['group_id']      = 'default'
 default['rvm']['group_users']   = []
 default['rvm']['rvmrc']         = Hash.new
 
-default['rvm']['installer_url'] = "https://rvm.beginrescueend.com/install/rvm"
+default['rvm']['installer_url'] = "https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer"
 
 default['rvm']['branch']  = nil
 default['rvm']['version'] = nil

--- a/cookbooks/rvm/metadata.rb
+++ b/cookbooks/rvm/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "fnichol@nichol.ca"
 license          "Apache 2.0"
 description      "Installs and manages RVM. Includes several LWRPs."
 long_description "Please refer to README.md (it's long)."
-version          "3.1.1.1"
+version          "3.1.2"
 
 recipe "rvm",               "Includes all recipes"
 recipe "rvm::system",       "Installs system-wide RVM"

--- a/cookbooks/rvm/metadata.rb
+++ b/cookbooks/rvm/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "fnichol@nichol.ca"
 license          "Apache 2.0"
 description      "Installs and manages RVM. Includes several LWRPs."
 long_description "Please refer to README.md (it's long)."
-version          "3.1.1"
+version          "3.1.1.1"
 
 recipe "rvm",               "Includes all recipes"
 recipe "rvm::system",       "Installs system-wide RVM"


### PR DESCRIPTION
The https://rvm.beginrescueend.com/install/rvm URL does not work for the initial download of the RVM installer.  Changing to one that does work.
