### PR TITLE
Route53 fix for zones with > 100 records

### DIFF
--- a/cookbooks/route53/libraries/route53.rb
+++ b/cookbooks/route53/libraries/route53.rb
@@ -33,7 +33,7 @@ begin
             requires :name, :type, :zone
             #
             batch = []
-            old_records = zone.records.select{|record| (record.name == self.name) && (record.type == self.type) }
+            old_records = zone.records.all!.select{|record| (record.name == self.name) && (record.type == self.type) }
             Chef::Log.info(["update record model", old_records].inspect)
             old_records.each do |record|
               batch << { :action => 'DELETE', :name => record.name, :resource_records => [*record.value], :ttl => record.ttl.to_s, :type => record.type }
@@ -96,7 +96,7 @@ module Opscode
       end
 
       def resource_record(zone, fqdn, type)
-        zone.records.detect{|record| (record.name == "#{fqdn}.") && (record.type == type) }
+        zone.records.get(fqdn,type,nil)
       end
 
       def safely(&block)


### PR DESCRIPTION
This uses methods from more recent (> 1.4.0) versions of fog to deal
with updating zones that have in excess of 100 records.  The AWS API
limits you to 100 records at a time when enumerating a zone.

The first change allows finding all of the matching records with
pagination.

The second is a much faster way to find whether or not a record
exists without having to deal with pagination.
