### PR TITLE
Fixed non-existant group, race condition wtih config file

### DIFF
--- a/cookbooks/mongodb/recipes/config_files.rb
+++ b/cookbooks/mongodb/recipes/config_files.rb
@@ -29,5 +29,5 @@ template "#{node[:mongodb][:conf_dir]}/mongodb.conf" do
   owner         "mongodb"
   group         "mongodb"
   mode          "0644" 
-  notifies      :restart, "service[mongodb_server]", :delayed if startable?(node[:mongodb][:server])
+  notify_startable_services(:mongodb, [:server])
 end

--- a/cookbooks/mongodb/recipes/default.rb
+++ b/cookbooks/mongodb/recipes/default.rb
@@ -25,9 +25,14 @@
 #
 
 if node[:mongodb][:server] # Only need user for servers
-  user node[:mongodb][:user] do
-    group node[:mongodb][:group]
+  group node[:mongodb][:group] do 
     action :create
+    system true
+    gid    node[:mongodb][:gid]
+  end 
+  user node[:mongodb][:user] do
+    action :create
+    group node[:mongodb][:group]
     system true
     shell "/bin/false"
   end

--- a/cookbooks/mongodb/recipes/server.rb
+++ b/cookbooks/mongodb/recipes/server.rb
@@ -47,7 +47,7 @@ kill_old_service('mongodb')
 
 runit_service "mongodb_server" do
   run_state     node[:mongodb][:server][:run_state]
-  options       Mash.new(node[:mongodb].to_hash).merge(node[:mongodb][:server].to_hash)
+  options       Mash.new(:service_name => 'server').merge(node[:mongodb]).merge(node[:mongodb][:server])
 end
 
 #


### PR DESCRIPTION
Hi. 

Adding the user was failing due to the group not existing.  Creating the group prior to adding the user (or not specifying a group at all) fixed this. 

Added notify_startable_services to config_files to prevent race conditions with the daemon and it's configuration.  
