### PR TITLE
Pig default version to 0.10.1

### DIFF
--- a/cookbooks/pig/attributes/default.rb
+++ b/cookbooks/pig/attributes/default.rb
@@ -1,7 +1,7 @@
 
 default[:pig][:home_dir]          = '/usr/lib/pig'
 
-default[:pig][:version]           = "0.9.2"
+default[:pig][:version]           = "0.10.1"
 default[:pig][:release_url]       = ":apache_mirror:/pig/pig-:version:/pig-:version:.tar.gz"
 
 default[:pig][:combine_splits]    = "true"


### PR DESCRIPTION
Pig default version to 0.10.1. 

There are significant improvements -- TO_MAP, nested FOREACH, etc. 

NOTE: you must remove the symlink at /usr/lib/pig yourself or chef won't apply a new version.

I validated that it installed and ran good
