### PR TITLE
Zookeeper depends on install_from

### DIFF
--- a/cookbooks/zookeeper/metadata.rb
+++ b/cookbooks/zookeeper/metadata.rb
@@ -12,6 +12,7 @@ depends          "runit"
 depends          "volumes"
 depends          "silverware"
 depends          "hadoop_cluster"
+depends          "install_from"
 
 recipe           "zookeeper::client",                  "Installs Zookeeper client libraries"
 recipe           "zookeeper::default",                 "Base configuration for zookeeper"


### PR DESCRIPTION
Adds `install_from` dependency to Zookeeper metadata. 

Chef-client fails without it.
