### PR TITLE
route53: Fix fog installation on rhel/variants

### DIFF
--- a/cookbooks/route53/recipes/default.rb
+++ b/cookbooks/route53/recipes/default.rb
@@ -18,20 +18,23 @@
 #
 
 # Force immediate install of these packages
-case node[:platform]
-when 'centos'
+case node[:platform_family]
+when 'rhel'
   package("libxml2-devel"    ){ action :nothing }.run_action(:install)
-else
+when 'debian'
   package("libxml2-dev"      ){ action :nothing }.run_action(:install)
   package("libxslt1-dev"     ){ action :nothing }.run_action(:install)
-  gem_package("fog") do
-    ignore_failure true
-    version '~> 1.5.0'
-    action :nothing
-  end.run_action(:install)
-  gem_package("net-ssh-multi"){ action :nothing }.run_action(:install)
-  gem_package("ghost"        ){ action :nothing }.run_action(:install)
+else
+  raise 'Unable to install route53 dependencies'
 end
+
+chef_gem("fog") do
+  ignore_failure true
+  version '~> 1.5.0'
+  action :nothing
+end.run_action(:install)
+chef_gem("net-ssh-multi"){ action :nothing }.run_action(:install)
+chef_gem("ghost"        ){ action :nothing }.run_action(:install)
 
 # Source the fog gem, forcing Gem to recognize new version if any
 


### PR DESCRIPTION
Fog gem installation was broken on rhel family distros.  This fixes it.
