### PR TITLE
changing core-site to use private_hostname rather than private_ip for fs.default.name

### DIFF
--- a/cookbooks/hadoop_cluster/recipes/config_files.rb
+++ b/cookbooks/hadoop_cluster/recipes/config_files.rb
@@ -25,7 +25,7 @@
 # Find these variables in ../hadoop_cluster/libraries/hadoop_cluster.rb
 #
 
-node[:hadoop][:namenode   ][:addr] = discover(:hadoop, :namenode   ).private_ip rescue nil
+node[:hadoop][:namenode   ][:addr] = discover(:hadoop, :namenode   ).private_hostname rescue nil
 node[:hadoop][:jobtracker ][:addr] = discover(:hadoop, :jobtracker ).private_ip rescue nil
 node[:hadoop][:secondarynn][:addr] = discover(:hadoop, :secondarynn).private_ip rescue nil
 


### PR DESCRIPTION
I'm assuming fs.default.name was originally set to the ip for a good reason, so Nate, would you take a look? Flip said this might create an issue with HBase.
