### PR TITLE
Remove dependency on ironfan facets

### DIFF
--- a/cookbooks/zookeeper/recipes/server.rb
+++ b/cookbooks/zookeeper/recipes/server.rb
@@ -67,7 +67,7 @@ if ((not node[:zookeeper][:zkid]) || (node[:zookeeper][:zkid].to_s != ''))
   # If zookeeper servers span facets, give each a well-sized offset in facet_role
   # (if 'bink' nodes have zkid_offset 10, 'foo-bink-7' would get zkid 17)
   #
-  node[:zookeeper][:zkid]  = node[:facet_index]
+  node[:zookeeper][:zkid]  = node[:hostname].match(/[^\d]*0*(\d+)$/)[1]
   node[:zookeeper][:zkid] += node[:zookeeper][:zkid_offset].to_i if node[:zookeeper][:zkid_offset]
 end
 

--- a/cookbooks/zookeeper/recipes/server.rb
+++ b/cookbooks/zookeeper/recipes/server.rb
@@ -67,7 +67,7 @@ if ((not node[:zookeeper][:zkid]) || (node[:zookeeper][:zkid].to_s != ''))
   # If zookeeper servers span facets, give each a well-sized offset in facet_role
   # (if 'bink' nodes have zkid_offset 10, 'foo-bink-7' would get zkid 17)
   #
-  node[:zookeeper][:zkid]  = node[:hostname].match(/[^\d]*0*(\d+)$/)[1]
+  node[:zookeeper][:zkid]  = node[:facet_index] || node[:hostname].match(/[^\d]*0*(\d+)$/)[1]
   node[:zookeeper][:zkid] += node[:zookeeper][:zkid_offset].to_i if node[:zookeeper][:zkid_offset]
 end
 


### PR DESCRIPTION
Use the hostname if the facet index doesn't exist to eliminate the dependency on being part of an ironfan cluster.  Retain the ability to specify an offset for repeating hostnames.
