### PR TITLE
Disable logging and monitoring for Kafka listeners

### DIFF
--- a/cookbooks/kafka/definitions/run_contrib_app.rb
+++ b/cookbooks/kafka/definitions/run_contrib_app.rb
@@ -81,7 +81,7 @@ define :run_contrib_app, app_type: nil, options: nil, daemon_count: nil, group_i
   end
   
   announce(:kafka_contrib, app_name.to_s.to_sym, {
-    logs:    log_monitor_info,
-    daemons: daemon_monitor_info,
+    # logs:    log_monitor_info,
+    # daemons: daemon_monitor_info,
   })
 end

--- a/cookbooks/kafka/definitions/run_contrib_app.rb
+++ b/cookbooks/kafka/definitions/run_contrib_app.rb
@@ -80,8 +80,5 @@ define :run_contrib_app, app_type: nil, options: nil, daemon_count: nil, group_i
     end
   end
   
-  announce(:kafka_contrib, app_name.to_s.to_sym, {
-    # logs:    log_monitor_info,
-    # daemons: daemon_monitor_info,
-  })
+  announce(:kafka_contrib, app_name.to_s.to_sym)
 end


### PR DESCRIPTION
Disabling logging and monitoring for kafka listeners so that Zabbix doesn't report false negatives but still allowing listeners to announce themselves, which is needed by tachyon.
