### PR TITLE
Add name to cookbook metadata so it can be used in Chef 12

### DIFF
--- a/cookbooks/install_from/metadata.rb
+++ b/cookbooks/install_from/metadata.rb
@@ -1,3 +1,4 @@
+name             "install_from"
 maintainer       "Philip (flip) Kromer - Infochimps, Inc"
 maintainer_email "coders@infochimps.com"
 license          "Apache 2.0"


### PR DESCRIPTION
See https://github.com/chef/chef/issues/2435
