### PR TITLE
Update default.rb

### DIFF
--- a/cookbooks/postgresql/attributes/default.rb
+++ b/cookbooks/postgresql/attributes/default.rb
@@ -195,8 +195,8 @@ end
 default['postgresql']['pg_hba'] = [
   {:type => 'local', :db => 'all', :user => 'postgres', :addr => nil, :method => 'ident'},
   {:type => 'local', :db => 'all', :user => 'all', :addr => nil, :method => 'ident'},
-  {:type => 'host', :db => 'all', :user => 'all', :addr => '127.0.0.1/32', :method => 'md5'},
-  {:type => 'host', :db => 'all', :user => 'all', :addr => '::1/128', :method => 'md5'}
+  {:type => 'host', :db => 'all', :user => 'all', :addr => '127.0.0.1/32', :method => 'sha512'},
+  {:type => 'host', :db => 'all', :user => 'all', :addr => '::1/128', :method => 'sha512'}
 ]
 
 default['postgresql']['password'] = Hash.new


### PR DESCRIPTION
MD5 has security weaknesses, better to use SHA 512. Any feedback is appreciated.